### PR TITLE
Fix `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@$(REPO_ROOT)/third_party/gardener/gardener/hack/format.sh ./cmd ./pkg
 
 .PHONY: test
-test: $(REPORT_COLLECTOR)
+test:
 	@$(REPO_ROOT)/third_party/gardener/gardener/hack/test.sh ./cmd/... ./pkg/...
 
 .PHONY: test-cov


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-custom-metrics/pull/13 `make test` fails with:
```
% make test

go build -o /Users/foo/SAPDevelop/go/src/github.com/gardener/gardener-custom-metrics/hack/tools/bin/report-collector github.com/gardener/gardener/hack/tools/report-collector
no required module provides package github.com/gardener/gardener/hack/tools/report-collector; to add it:
	go get github.com/gardener/gardener/hack/tools/report-collector
make: *** [/Users/foo/SAPDevelop/go/src/github.com/gardener/gardener-custom-metrics/hack/tools/bin/report-collector] Error 1
```

The `report-collector` tool is only used when running in prow, see: https://github.com/gardener/gardener-custom-metrics/blob/4a090f6b57b525540bcf53c64bb401321a2ec201/third_party/gardener/gardener/hack/test.sh#L24-L36
We haven't yet switched to prow. Even in that case, the report-collector tool is not required.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
