### PR TITLE
Clean up Endpoints object

### DIFF
--- a/pkg/ha/ha_service.go
+++ b/pkg/ha/ha_service.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -69,7 +69,7 @@ func (ha *HAService) setEndpoints(ctx context.Context) error {
 	// Bypass client cache to avoid triggering a cluster wide list-watch for Endpoints - our RBAC does not allow it
 	err := ha.manager.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("updating the service endpoint to point to the new leader: retrieving endpoints: %w", err)
 		}
 
@@ -99,7 +99,7 @@ func (ha *HAService) Start(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			_ = ha.cleanUp()
+			_ = ha.cleanUpServiceEndpoints()
 			return fmt.Errorf("starting HA service: %w", ctx.Err())
 		case <-ha.testIsolation.TimeAfter(retryPeriod):
 		}
@@ -111,16 +111,16 @@ func (ha *HAService) Start(ctx context.Context) error {
 	}
 
 	<-ctx.Done()
-	err := ha.cleanUp()
+	err := ha.cleanUpServiceEndpoints()
 	if err == nil {
 		err = ctx.Err()
 	}
 	return err
 }
 
-// cleanUp is executed upon ending leadership. Its purpose is to remove the Endpoints object created upon acquiring
+// cleanUpServiceEndpoints is executed upon ending leadership. Its purpose is to remove the Endpoints object created upon acquiring
 // leadership.
-func (ha *HAService) cleanUp() error {
+func (ha *HAService) cleanUpServiceEndpoints() error {
 	// Use our own context. This function executes when the main application context is closed.
 	// Also, try to finish before a potential 15 seconds termination grace timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), 14*time.Second)
@@ -130,8 +130,13 @@ func (ha *HAService) cleanUp() error {
 	attempt := 0
 	var err error
 	for {
-		endpoints := corev1.Endpoints{}
-		err = seedClient.Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
+		endpoints := corev1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      app.Name,
+				Namespace: ha.namespace,
+			},
+		}
+		err = seedClient.Get(ctx, client.ObjectKeyFromObject(&endpoints), &endpoints)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				ha.log.V(app.VerbosityVerbose).Info("The endpoints object cleanup succeeded: the object was missing")
@@ -141,14 +146,7 @@ func (ha *HAService) cleanUp() error {
 			ha.log.V(app.VerbosityInfo).Info("Failed to retrieve the endpoints object", "error", err.Error())
 		} else {
 			// Avoid data race. We don't want to delete the endpoint if it is sending traffic to a replica other than this one.
-			isEndpointStillPointingToOurReplica :=
-				len(endpoints.Subsets) == 1 &&
-					len(endpoints.Subsets[0].Addresses) == 1 &&
-					endpoints.Subsets[0].Addresses[0].IP == ha.servingIPAddress &&
-					len(endpoints.Subsets[0].Ports) == 1 &&
-					endpoints.Subsets[0].Ports[0].Port == int32(ha.servingPort) &&
-					endpoints.Subsets[0].Ports[0].Protocol == corev1.ProtocolTCP
-			if !isEndpointStillPointingToOurReplica {
+			if !ha.isEndpointStillPointingToOurReplica(&endpoints) {
 				// Someone else is using the endpoint. We can't perform safe cleanup. Abandon the object.
 				ha.log.V(app.VerbosityWarning).Info(
 					"Abandoning endpoints object because it was modified by an external actor")
@@ -176,4 +174,14 @@ func (ha *HAService) cleanUp() error {
 
 	ha.log.V(app.VerbosityError).Error(err, "All retries to delete the endpoints object failed. Abandoning object.")
 	return fmt.Errorf("HAService cleanup: deleting endponts object: retrying failed, last error: %w", err)
+}
+
+// Does the endpoints object hold the same values as the ones we previously set to it?
+func (ha *HAService) isEndpointStillPointingToOurReplica(endpoints *corev1.Endpoints) bool {
+	return len(endpoints.Subsets) == 1 &&
+		len(endpoints.Subsets[0].Addresses) == 1 &&
+		endpoints.Subsets[0].Addresses[0].IP == ha.servingIPAddress &&
+		len(endpoints.Subsets[0].Ports) == 1 &&
+		endpoints.Subsets[0].Ports[0].Port == int32(ha.servingPort) &&
+		endpoints.Subsets[0].Ports[0].Protocol == corev1.ProtocolTCP
 }

--- a/pkg/ha/ha_service_test.go
+++ b/pkg/ha/ha_service_test.go
@@ -6,15 +6,16 @@ package ha
 
 import (
 	"context"
-	"sync/atomic"
-	"time"
-
+	"fmt"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sync/atomic"
+	"time"
 
 	"github.com/gardener/gardener-custom-metrics/pkg/app"
 	"github.com/gardener/gardener-custom-metrics/pkg/util/testutil"
@@ -26,98 +27,84 @@ var _ = Describe("HAService", func() {
 		testIPAddress = "1.2.3.4"
 		testPort      = 777
 	)
+	// Helper functions
+	var (
+		makeEmptyEndpointsObject = func(namespace string) *corev1.Endpoints {
+			return &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      app.Name,
+					Namespace: namespace,
+				},
+			}
+		}
+		arrange = func() (*HAService, *testutil.FakeManager, context.Context, context.CancelFunc) {
+			manager := testutil.NewFakeManager()
+			ha := NewHAService(manager, testNs, testIPAddress, testPort, logr.Discard())
+			ctx, cancel := context.WithCancel(context.Background())
+			return ha, manager, ctx, cancel
+		}
+		createEndpointsObjectOnServer = func(namespace string, client kclient.Client) {
+			endpoints := makeEmptyEndpointsObject(namespace)
+			Expect(client.Create(context.Background(), endpoints)).To(Succeed())
+		}
+		waitGetChangedEndpoints = func(ha *HAService, actualEndpoints *corev1.Endpoints) error {
+			// This function returns nil if the endpoints object exists and has changed from its initial, unpopulated state
+
+			err := ha.manager.GetClient().Get(
+				context.Background(), kclient.ObjectKey{Namespace: ha.namespace, Name: app.Name}, actualEndpoints)
+			if err != nil {
+				return err
+			}
+			if actualEndpoints.Subsets == nil {
+				return fmt.Errorf("endpoiints object not populated")
+			}
+			return nil
+		}
+		expectEndpointsPopulated = func(actualEndpoints *corev1.Endpoints) {
+			Expect(actualEndpoints.Labels).NotTo(BeNil())
+			Expect(actualEndpoints.Labels["app"]).To(Equal(app.Name))
+			Expect(actualEndpoints.Subsets).To(HaveLen(1))
+			Expect(actualEndpoints.Subsets[0].Addresses).To(HaveLen(1))
+			Expect(actualEndpoints.Subsets[0].Addresses[0].IP).To(Equal(testIPAddress))
+			Expect(actualEndpoints.Subsets[0].Ports).To(HaveLen(1))
+			Expect(actualEndpoints.Subsets[0].Ports[0].Port).To(Equal(int32(testPort)))
+		}
+	)
 
 	Describe("Start", func() {
-		It("should set the respective service endpoints ", func() {
+		It("should create/update the respective service endpoints object ", func() {
 			// Arrange
-			manager := testutil.NewFakeManager()
-			ha := NewHAService(manager, testNs, testIPAddress, testPort, logr.Discard())
-
-			endpoints := &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      app.Name,
-					Namespace: ha.namespace,
-				},
-			}
-			Expect(ha.manager.GetClient().Create(context.Background(), endpoints)).To(Succeed())
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// So, create an empty object in the fake client first.
+			createEndpointsObjectOnServer(ha.namespace, ha.manager.GetClient())
+			var err error
 
 			// Act
-			err := ha.Start(context.Background())
-
-			// Assert
-			Expect(err).To(Succeed())
-			actual := corev1.Endpoints{}
-			manager.GetClient().Get(context.Background(), kclient.ObjectKey{Namespace: testNs, Name: app.Name}, &actual)
-			Expect(actual.Labels).NotTo(BeNil())
-			Expect(actual.Labels["app"]).To(Equal(app.Name))
-			Expect(actual.Subsets).To(HaveLen(1))
-			Expect(actual.Subsets[0].Addresses).To(HaveLen(1))
-			Expect(actual.Subsets[0].Addresses[0].IP).To(Equal(testIPAddress))
-			Expect(actual.Subsets[0].Ports).To(HaveLen(1))
-			Expect(actual.Subsets[0].Ports[0].Port).To(Equal(int32(testPort)))
-		})
-
-		It("should wait and retry with exponential backoff, if the service endpoints are missing, and succeed "+
-			"once they appear", func() {
-
-			// Arrange
-			manager := testutil.NewFakeManager()
-			ha := NewHAService(manager, testNs, testIPAddress, testPort, logr.Discard())
-			timeAfterChan := make(chan time.Time)
-			var timeAfterDuration atomic.Int64
-			ha.testIsolation.TimeAfter = func(duration time.Duration) <-chan time.Time {
-				timeAfterDuration.Store(int64(duration))
-				return timeAfterChan
-			}
-			var err error
-			var isComplete atomic.Bool
-
-			// Act and assert
 			go func() {
-				err = ha.Start(context.Background())
-				isComplete.Store(true)
+				err = ha.Start(ctx)
 			}()
 
-			Consistently(isComplete.Load).Should(BeFalse())
-			Expect(timeAfterDuration.Load()).To(Equal(int64(1 * time.Second)))
-
-			timeAfterChan <- time.Now()
-			Consistently(isComplete.Load).Should(BeFalse())
-			Expect(timeAfterDuration.Load()).To(Equal(int64(2 * time.Second)))
-
-			endpoints := &corev1.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      app.Name,
-					Namespace: ha.namespace,
-				},
-			}
-			Expect(ha.manager.GetClient().Create(context.Background(), endpoints)).To(Succeed())
-
-			timeAfterChan <- time.Now()
-
-			Eventually(isComplete.Load).Should(BeTrue())
-			Expect(err).To(Succeed())
-			actual := corev1.Endpoints{}
-			manager.GetClient().Get(context.Background(), kclient.ObjectKey{Namespace: testNs, Name: app.Name}, &actual)
-			Expect(actual.Subsets).To(HaveLen(1))
-			Expect(actual.Subsets[0].Addresses).To(HaveLen(1))
-			Expect(actual.Subsets[0].Addresses[0].IP).To(Equal(testIPAddress))
+			// Assert
+			actualEndpoints := makeEmptyEndpointsObject(ha.namespace)
+			Eventually(func() error { return waitGetChangedEndpoints(ha, actualEndpoints) }).Should(Succeed())
+			Expect(err).NotTo(HaveOccurred())
+			expectEndpointsPopulated(actualEndpoints)
 		})
 
 		It("should immediately abort retrying, if the context gets canceled", func() {
 			// Arrange
-			manager := testutil.NewFakeManager()
-			ha := NewHAService(manager, testNs, testIPAddress, testPort, logr.Discard())
+			ha, manager, ctx, cancel := arrange()
+			defer cancel()
+			var err error
+			var isComplete atomic.Bool
 
 			timeAfterChan := make(chan time.Time)
 			ha.testIsolation.TimeAfter = func(_ time.Duration) <-chan time.Time {
 				return timeAfterChan
 			}
-
-			var err error
-			var isComplete atomic.Bool
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 
 			// Act and assert
 			go func() {
@@ -126,6 +113,11 @@ var _ = Describe("HAService", func() {
 			}()
 
 			timeAfterChan <- time.Now()
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// Here we rely on this failure to halt the progress of configuring the endpoints objects.
+			// In the real world, the cause of the faults would be different, but that should trigger the same retry
+			// mechanic.
 			Consistently(isComplete.Load).Should(BeFalse())
 
 			cancel()
@@ -136,11 +128,15 @@ var _ = Describe("HAService", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should use exponential backoff", func() {
+		It("should wait and retry with exponential backoff, if the service endpoints are missing, and succeed "+
+			"once they appear", func() {
 
 			// Arrange
-			manager := testutil.NewFakeManager()
-			ha := NewHAService(manager, testNs, testIPAddress, testPort, logr.Discard())
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			var err error
+			var isComplete atomic.Bool
+
 			timeAfterChan := make(chan time.Time)
 			var timeAfterDuration atomic.Int64
 			ha.testIsolation.TimeAfter = func(duration time.Duration) <-chan time.Time {
@@ -150,9 +146,52 @@ var _ = Describe("HAService", func() {
 
 			// Act and assert
 			go func() {
-				ha.Start(context.Background())
+				err = ha.Start(ctx)
+				isComplete.Store(true)
 			}()
 
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// Here we rely on this failure to halt the progress of configuring the endpoints objects.
+			// In the real world, the cause of the faults would be different, but that should trigger the same retry
+			// mechanic.
+			Consistently(isComplete.Load).Should(BeFalse())
+			Expect(timeAfterDuration.Load()).To(Equal(int64(1 * time.Second)))
+
+			timeAfterChan <- time.Now()
+			Consistently(isComplete.Load).Should(BeFalse())
+			Expect(timeAfterDuration.Load()).To(Equal(int64(2 * time.Second)))
+
+			createEndpointsObjectOnServer(ha.namespace, ha.manager.GetClient())
+			timeAfterChan <- time.Now()
+
+			actualEndpoints := makeEmptyEndpointsObject(ha.namespace)
+			Eventually(func() error { return waitGetChangedEndpoints(ha, actualEndpoints) }).Should(Succeed())
+			Expect(err).To(Succeed())
+			expectEndpointsPopulated(actualEndpoints)
+		})
+
+		It("should use exponential backoff", func() {
+			// Arrange
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			timeAfterChan := make(chan time.Time)
+			var timeAfterDuration atomic.Int64
+			ha.testIsolation.TimeAfter = func(duration time.Duration) <-chan time.Time {
+				timeAfterDuration.Store(int64(duration))
+				return timeAfterChan
+			}
+
+			// Act and assert
+			go func() {
+				_ = ha.Start(ctx)
+			}()
+
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// Here we rely on this failure to halt the progress of configuring the endpoints objects.
+			// In the real world, the cause of the faults would be different, but that should trigger the same retry
+			// mechanic.
 			expectedPeriod := 1 * time.Second
 			expectedMax := 5 * time.Minute
 			for i := 0; i < 20; i++ {
@@ -164,6 +203,101 @@ var _ = Describe("HAService", func() {
 				timeAfterChan <- time.Now()
 			}
 			Consistently(timeAfterDuration.Load).Should(Equal(int64(expectedMax)))
+		})
+
+		It("should delete its service endpoint when context closes", func() {
+			// Arrange
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			var err error
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// So, create an empty object in the fake client first.
+			createEndpointsObjectOnServer(ha.namespace, ha.manager.GetClient())
+
+			// Act & assert
+			go func() {
+				err = ha.Start(ctx)
+			}()
+
+			// Wait for HAService to update the Endpoints object
+			actualEndpoints := makeEmptyEndpointsObject(ha.namespace)
+			Eventually(func() error { return waitGetChangedEndpoints(ha, actualEndpoints) }).Should(Succeed())
+
+			cancel()
+
+			// Wait for HAService to delete update the Endpoints object
+			Eventually(func() bool {
+				err := ha.manager.GetClient().Get(
+					context.Background(), kclient.ObjectKey{Namespace: ha.namespace, Name: app.Name}, actualEndpoints)
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			Expect(err.Error()).To(ContainSubstring("canceled"))
+		})
+
+		It("upon exit, cleanup should not delete the service endpoint if it points to a different IP address", func() {
+			// Arrange
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			var err error
+			var isComplete atomic.Bool
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// So, create an empty object in the fake client first.
+			createEndpointsObjectOnServer(ha.namespace, ha.manager.GetClient())
+
+			// Act & assert
+			go func() {
+				err = ha.Start(ctx)
+				isComplete.Store(true)
+			}()
+
+			// Wait for HAService to update the Endpoints object
+			actualEndpoints := makeEmptyEndpointsObject(ha.namespace)
+			Eventually(func() error { return waitGetChangedEndpoints(ha, actualEndpoints) }).Should(Succeed())
+
+			// Modify the Endpoints object so it no longer points to our pod
+			actualEndpoints.Subsets[0].Addresses[0].IP = "1.1.1.1"
+			Expect(ha.manager.GetClient().Update(ctx, actualEndpoints)).To(Succeed())
+
+			cancel()
+
+			// Make sure the HAService did not delete the Endpoints object
+			Eventually(isComplete.Load).Should(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("canceled"))
+			Expect(
+				ha.manager.GetClient().Get(
+					context.Background(), kclient.ObjectKey{Namespace: ha.namespace, Name: app.Name}, actualEndpoints)).
+				To(Succeed())
+		})
+
+		It("upon exit, cleanup should succeed if endpoints object is deleted by an external actor", func() {
+			// Arrange
+			ha, _, ctx, cancel := arrange()
+			defer cancel()
+			var err error
+			var isComplete atomic.Bool
+			// Real K8s API HTTP PUT does create/update and works file if the Endpoints object is missing. The update
+			// operation of the client type in the test fake library we use, fails if the object is missing.
+			// So, create an empty object in the fake client first.
+			createEndpointsObjectOnServer(ha.namespace, ha.manager.GetClient())
+
+			// Act & assert
+			go func() {
+				err = ha.Start(ctx)
+				isComplete.Store(true)
+			}()
+
+			// Wait for HAService to update the Endpoints object
+			actualEndpoints := makeEmptyEndpointsObject(ha.namespace)
+			Eventually(func() error { return waitGetChangedEndpoints(ha, actualEndpoints) }).Should(Succeed())
+
+			// Delete the Endpoints object before triggering cleanup. Error should be "context canceled" and not e.g. "not found"
+			Expect(ha.manager.GetClient().Delete(ctx, actualEndpoints)).To(Succeed())
+			cancel()
+			Eventually(isComplete.Load).Should(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("canceled"))
 		})
 	})
 })

--- a/pkg/ha/ha_service_test.go
+++ b/pkg/ha/ha_service_test.go
@@ -7,6 +7,9 @@ package ha
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"time"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,8 +17,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sync/atomic"
-	"time"
 
 	"github.com/gardener/gardener-custom-metrics/pkg/app"
 	"github.com/gardener/gardener-custom-metrics/pkg/util/testutil"


### PR DESCRIPTION
**Change description:**
GCMx, upon exiting leader role, now opportunistically deletes the service Endpoints object it configured for itself when it entered leadership role.

**Notes:**
If you want to test this function on a GCMx which was launched via scaffold debug, deleting the pod won't work, because PID=1 would be DLV, not GCMx. You'd need to either terminate leadership, or directly send SIG_TERM to the GCMx process. With a pod which was not launched via skaffold/DLV, you can just delete the pod.

Before this change, HAService.Run() used to exit quickly - it only needed to arrange the Endpoints object. After the change, HAService.Run() blocks for the duration of the program execution, because it is not responsible for the cleanup upon program termination. This is reflected by a change in the unit tests.