### PR TITLE
Add liveness and readiness probes to the example Deployment

### DIFF
--- a/example/custom-metrics-deployment.yaml
+++ b/example/custom-metrics-deployment.yaml
@@ -44,11 +44,26 @@ spec:
                   fieldPath: metadata.namespace
           image: europe-docker.pkg.dev/gardener-project/releases/gardener/gardener-custom-metrics:v0.1.0-dev
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
           name: gardener-custom-metrics
           ports:
             - containerPort: 6443
-              name: metrics-server
-              protocol: TCP
+              name: https
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 10
+            periodSeconds: 10
           resources:
             requests:
               cpu: 80m


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Add liveness and readiness probes to the example Deployment. The `/livez` and `/readyz` endpoints are exposed by default and don't require authentication.

```
$ curl -k https://localhost:6443/livez?verbose
[+]ping ok
[+]log ok
[+]poststarthook/max-in-flight-filter ok
livez check passed

$ curl -k https://localhost:6443/readyz?verbose
[+]ping ok
[+]log ok
[+]poststarthook/max-in-flight-filter ok
[+]shutdown ok
readyz check passed
```

**Which issue(s) this PR fixes**:
Part of #5 
Part of https://github.com/gardener/gardener/issues/8259

**Special notes for your reviewer**:
I didn't look into whether we can add more livez/readyz checks: for example the controller-runtime's informers synced check. Right now, we are using the default  livez/readyz checks from the custom-metrics-apiserver (or generic apiserver) and these checks don't check anything specific the the gardener-custom-metrics or to the controller-runtime's manager. I.e., we won't have a failing liveness/readiness probe if the controller-runtime's manager's informer is not synced.

For now, I didn't invest into this direction as in #6 there was the following idea from @plkokanov :
> - Did you consider the https://github.com/kubernetes/client-go/tree/master/tools/cache package instead of the pod and secret controllers and listing the pods/secrets right before scraping metrics? The pods/secret should be available in the cache.

To drop the current controllers in favor of the https://github.com/kubernetes/client-go/tree/master/tools/cache package.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
