### PR TITLE
Update example RBAC

### DIFF
--- a/example/rbac.yaml
+++ b/example/rbac.yaml
@@ -4,115 +4,105 @@ metadata:
   name: gardener-custom-metrics
   namespace: garden
 automountServiceAccountToken: true
-
---- # Role: endpoint-editor
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gardener-custom-metrics
+  namespace: garden
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  resourceNames:
+  - gardener-custom-metrics
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - gardener-custom-metrics-leader-election
+  resources:
+  - leases
+  verbs:
+  - get
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gardener-custom-metrics
+  namespace: garden
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gardener-custom-metrics
+subjects:
+- kind: ServiceAccount
+  name: gardener-custom-metrics
+  namespace: garden
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gardener-custom-metrics-endpoint-editor
+  name: gardener-custom-metrics
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-    # resourceNames: [ "gardener-custom-metrics" ] # TODO: Andrey: P1: How to write code so we can use name-based restriction?
-    verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener-custom-metrics--endpoint-editor
+  name: gardener-custom-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener-custom-metrics-endpoint-editor
+  name: gardener-custom-metrics
 subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
-
---- # Role: custom-metrics-editor
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: gardener-custom-metrics-custom-metrics-editor
-    rules:
-      - apiGroups:
-          - custom.metrics.k8s.io
-        resources: ["*"]
-        verbs: ["*"]
+- kind: ServiceAccount
+  name: gardener-custom-metrics
+  namespace: garden
+# Bindings to externally defined roles
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: gardener-custom-metrics--custom-metrics-editor
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gardener-custom-metrics-custom-metrics-editor
-subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
-
---- # Role: pod-reader
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gardener-custom-metrics-pod-reader
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: gardener-custom-metrics--pod-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gardener-custom-metrics-pod-reader
-subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
-
---- # Role: secret-reader
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gardener-custom-metrics-secret-reader
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    # resourceNames: [ "ca", "shoot-access-gardener-custom-metrics" ] # TODO: Andrey: P1: How to write code so we can use name-based restriction?
-    verbs:
-      - get
-      - list
-      - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: gardener-custom-metrics--secret-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: gardener-custom-metrics-secret-reader
-subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
-
---- # Bindings to externally defined roles ####################################
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -122,9 +112,9 @@ roleRef:
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
+- kind: ServiceAccount
+  name: gardener-custom-metrics
+  namespace: garden
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -136,6 +126,6 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
-  - kind: ServiceAccount
-    name: gardener-custom-metrics
-    namespace: garden
+- kind: ServiceAccount
+  name: gardener-custom-metrics
+  namespace: garden

--- a/example/rbac.yaml
+++ b/example/rbac.yaml
@@ -76,13 +76,6 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
@plkokanov reported that there are missing RBAC rules for leader election and events in the example RBACs.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8259

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
