### PR TITLE
Address review comments, avoid reconcile loop upon missing secret

### DIFF
--- a/pkg/ha/ha_service.go
+++ b/pkg/ha/ha_service.go
@@ -65,7 +65,8 @@ func NewHAService(
 
 func (ha *HAService) setEndpoints(ctx context.Context) error {
 	endpoints := corev1.Endpoints{}
-	err := ha.manager.GetClient().Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
+	// Bypass client cache to avoid triggering a cluster wide list-watch for Endpoints - our RBAC does not allow it
+	err := ha.manager.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("updating the service endpoint to point to the new leader: retrieving endpoints: %w", err)

--- a/pkg/input/cli_options.go
+++ b/pkg/input/cli_options.go
@@ -55,7 +55,7 @@ func (options *CLIOptions) AddFlags(flags *pflag.FlagSet) {
 		minSampleGapFlagName,
 		options.MinSampleGap,
 		fmt.Sprintf(
-			"How often do we adjust the level of parallelism we use for scraping pod metrics. Default: %d",
+			"If the last two metrics samples are closer in time than this, don't use them to calculate rate. Default: %d",
 			options.MinSampleGap))
 }
 

--- a/pkg/input/controller/pod/actuator.go
+++ b/pkg/input/controller/pod/actuator.go
@@ -88,7 +88,7 @@ func (a *actuator) Delete(_ context.Context, obj client.Object) (requeueAfter ti
 	}
 
 	if !a.dataRegistry.RemoveKapiData(pod.Namespace, pod.Name) {
-		log.Error(nil, "Controller was notified about deletion of a pod it was not currently tracking")
+		log.V(app.VerbosityInfo).Info("Controller was notified about deletion of a pod it was not currently tracking")
 	}
 
 	return 0, nil

--- a/pkg/input/controller/reconciler_test.go
+++ b/pkg/input/controller/reconciler_test.go
@@ -44,9 +44,9 @@ var _ = Describe("input.controller.reconciler", func() {
 	)
 
 	Describe("Reconcile", func() {
-		It("should have no effect if the object is missing", func() {
+		It("should delegate to the actuator's delete function if the object is missing", func() {
 			// Arrange
-			reconciler, _, client, _ := newTestReconciler()
+			reconciler, actuator, client, _ := newTestReconciler()
 			client.GetFunc = func(_ context.Context, key kclient.ObjectKey, _ kclient.Object) error {
 				return errors.NewNotFound(schema.GroupResource{}, key.Name)
 			}
@@ -59,6 +59,7 @@ var _ = Describe("input.controller.reconciler", func() {
 			// Assert
 			Expect(err).To(Succeed())
 			Expect(result.Requeue).To(BeFalse())
+			Expect(int(actuator.CallType)).To(Equal(callTypeDelete))
 		})
 		It("should use a deep copy of the client's prototype objet, not the prototype itself", func() {
 			// Arrange

--- a/pkg/input/input_data_registry/input_data_registry.go
+++ b/pkg/input/input_data_registry/input_data_registry.go
@@ -508,7 +508,7 @@ func (reg *inputDataRegistry) RemoveKapiWatcher(watcher *KapiWatcher) bool {
 	return false
 }
 
-// Caller must acquire read lock before calling this function
+// Caller must acquire read lock before calling this function (or a semantic extension of a read lock - e.g. a read-write lock)
 func (reg *inputDataRegistry) notifyKapiWatchersThreadUnsafe(kapi *KapiData, event KapiEventType) {
 	for _, watcher := range reg.kapiWatchers {
 		(*watcher)(&kapiDataAdapter{x: kapi}, event)

--- a/pkg/util/testutil/fake_manager.go
+++ b/pkg/util/testutil/fake_manager.go
@@ -66,7 +66,7 @@ func (f *FakeManager) GetRESTMapper() meta.RESTMapper {
 }
 
 func (f *FakeManager) GetAPIReader() client.Reader {
-	panic("implement me")
+	return f.Client
 }
 
 // GetRunnables returns the subset of FakeManagers' runnables, which are assertable to the specified type


### PR DESCRIPTION
Applies suggestions from code reviews. Most notably, addresses a bug where a missing secret leads to endlessly retrying (requeueing) the reconcile. 