### PR TITLE
Restrict Endpoints watch by namespace

### DIFF
--- a/pkg/ha/ha_service.go
+++ b/pkg/ha/ha_service.go
@@ -65,7 +65,8 @@ func NewHAService(
 
 func (ha *HAService) setEndpoints(ctx context.Context) error {
 	endpoints := corev1.Endpoints{}
-	err := ha.manager.GetClient().Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
+	// Bypass client cache to avoid triggering a cluster wide list-watch for Endpoints - our RBAC does not allow it
+	err := ha.manager.GetAPIReader().Get(ctx, client.ObjectKey{Namespace: ha.namespace, Name: app.Name}, &endpoints)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("updating the service endpoint to point to the new leader: retrieving endpoints: %w", err)

--- a/pkg/util/testutil/fake_manager.go
+++ b/pkg/util/testutil/fake_manager.go
@@ -66,7 +66,7 @@ func (f *FakeManager) GetRESTMapper() meta.RESTMapper {
 }
 
 func (f *FakeManager) GetAPIReader() client.Reader {
-	panic("implement me")
+	return f.Client
 }
 
 // GetRunnables returns the subset of FakeManagers' runnables, which are assertable to the specified type


### PR DESCRIPTION
Restricts the Endpoints watch to the garden namespace, so that it can be compatible with a namespace-scoped RBAC.