### PR TITLE
Restrict the manager's cache to concrete objects with label selectors

### DIFF
--- a/example/custom-metrics-deployment.yaml
+++ b/example/custom-metrics-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           resources:
             requests:
               cpu: 80m
-              memory: 800Mi
+              memory: 200Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Currently the memory usage of the gardener-custom-metrics is high because we are watching all Pods/Secrets in the Seed cluster:
```
# for 13972 Secrets
% k -n garden top po -l app=gardener-custom-metrics
NAME                                             CPU(cores)   MEMORY(bytes)
gardener-custom-metrics-debug-5477b66b44-wwchg   25m          496Mi

# for 934 Secrets
% k -n garden top po -l app=gardener-custom-metrics
NAME                                             CPU(cores)   MEMORY(bytes)
gardener-custom-metrics-debug-78b9b65ff5-5j2wd   6m           167Mi
gardener-custom-metrics-debug-78b9b65ff5-zbvwv   1m           16Mi
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8259

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
