### PR TITLE
Revert "Add liveness and readiness probes to the example Deployment (#18)"

### DIFF
--- a/example/custom-metrics-deployment.yaml
+++ b/example/custom-metrics-deployment.yaml
@@ -44,26 +44,11 @@ spec:
                   fieldPath: metadata.namespace
           image: europe-docker.pkg.dev/gardener-project/releases/gardener/gardener-custom-metrics:v0.1.0-dev
           imagePullPolicy: IfNotPresent
-          livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /livez
-              port: https
-              scheme: HTTPS
-            initialDelaySeconds: 10
-            periodSeconds: 10
           name: gardener-custom-metrics
           ports:
             - containerPort: 6443
-              name: https
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /readyz
-              port: https
-              scheme: HTTPS
-            initialDelaySeconds: 10
-            periodSeconds: 10
+              name: metrics-server
+              protocol: TCP
           resources:
             requests:
               cpu: 80m


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
This PR reverts commit bde476833869411e44a7003cef5ad7aba4120e91.

Currently the readiness and liveness probes don't pass against the passive replica. The reason is that in https://github.com/gardener/gardener-custom-metrics/blob/3859e6b44c21807c07cb8f5b7634ce86a8570708/cmd/gardener-custom-metrics/main.go#L171-L182 the Runnable that starts the manager is only added for the leader replica.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
