### PR TITLE
Clean up the prepare_release script calls from the pipeline definitions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -49,8 +49,6 @@ gardener-custom-metrics:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
-          next_version_callback: '.ci/prepare_release'
-          release_callback: '.ci/prepare_release'
 #        slack:
 #          default_channel: 'internal_scp_workspace'
 #          channel_cfgs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Currently the release step fails with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/build/01f561ac/git-gardener.gardener-custom-metrics-main/.ci/prepare_release'
```

In https://github.com/gardener/gardener-custom-metrics/pull/13/commits/6e4d7e017d55d477d804ad7234198a0d61a79663, I dropped this script with the motivation that it is used only by extensions and should not be needed for our repo. However, I missed to adapt the pipeline_defiinitions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
